### PR TITLE
Update Init process

### DIFF
--- a/files/inittab
+++ b/files/inittab
@@ -1,7 +1,8 @@
 # /etc/inittab
 ::sysinit:/hab/bin/hab pkg exec core/coreutils echo STARTING SYSTEM
 ::sysinit:/etc/init.d/startup
-::sysinit:/etc/init.d/hab
+:3:initdefault:
+:3:respawn:/hab/bin/hab pkg exec core/busybox-static runsvdir /etc/rc.d
 tty1::respawn:/hab/bin/hab pkg exec core/busybox-static getty 38400 tty1
 tty2::respawn:/hab/bin/hab pkg exec core/busybox-static getty 38400 tty2
 tty3::respawn:/hab/bin/hab pkg exec core/busybox-static getty 38400 tty3

--- a/plan.sh
+++ b/plan.sh
@@ -11,6 +11,7 @@ pkg_deps=(
   core/e2fsprogs
   core/hab
   core/gawk
+  core/sed
   core/findutils
 )
 pkg_bin_dirs=(bin)


### PR DESCRIPTION
This is an attempt to start services on boot and give us a login prompt, rather than a `hab sup bash` shell.  It also puts the system packages in your $PATH to make the debugging experience a little nicer. 

Runsvdir starts up, but doesn't execute services contained in /etc/rc.d .  I think this is fine for now as it moves us a little closer to an MVP and will help with the debugging process. 